### PR TITLE
ignore unicode surrogates during tests

### DIFF
--- a/simple/test/src/Main.idr
+++ b/simple/test/src/Main.idr
@@ -145,10 +145,23 @@ bits64All : Gen Bits64
 bits64All = bits64 $ exponential 0 18446744073709551615
 
 unicode16 : Gen Char
-unicode16 = noControl <$> charc '\0' '\65535'
+unicode16 = noSpecial <$> charc '\0' '\65535'
   where
     noControl : Char -> Char
     noControl c = if isControl c then ' ' else c
+
+    noHighSurrogate : Char -> Char
+    noHighSurrogate c =
+      let idx = ord c
+      in if idx >= 0xD800 && idx <= 0xDBFF then ' ' else c
+
+    noLowSurrogate : Char -> Char
+    noLowSurrogate c =
+      let idx = ord c
+      in if idx >= 0xDC00 && idx <= 0xDFFF then ' ' else c
+
+    noSpecial : Char -> Char
+    noSpecial = noControl . noHighSurrogate . noLowSurrogate
 
 doubleE100 : Gen Double
 doubleE100 = double $ exponentialFrom 0 (-1.0e100) 1.0e100

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -145,10 +145,23 @@ bits64All : Gen Bits64
 bits64All = bits64 $ exponential 0 18446744073709551615
 
 unicode16 : Gen Char
-unicode16 = noControl <$> charc '\0' '\65535'
+unicode16 = noSpecial <$> charc '\0' '\65535'
   where
     noControl : Char -> Char
     noControl c = if isControl c then ' ' else c
+
+    noHighSurrogate : Char -> Char
+    noHighSurrogate c =
+      let idx = ord c
+      in if idx >= 0xD800 && idx <= 0xDBFF then ' ' else c
+
+    noLowSurrogate : Char -> Char
+    noLowSurrogate c =
+      let idx = ord c
+      in if idx >= 0xDC00 && idx <= 0xDFFF then ' ' else c
+
+    noSpecial : Char -> Char
+    noSpecial = noControl . noHighSurrogate . noLowSurrogate
 
 doubleE100 : Gen Double
 doubleE100 = double $ exponentialFrom 0 (-1.0e100) 1.0e100


### PR DESCRIPTION
Main motivation is to make tests pass on Go backend, as it is using UTF-8 encoded strings and UTF-8 treats surrogate pairs ill-formed. In this case Go uses the unicode replacement character instead, so breaking the round trip tests.

According to the Unicode standard, any surrogate is ill-formed in UTF-8 and UTF-32, regardless it is a single surrogate or appears in pairs.
A single surrogate is ill formed in UTF-16, as surrogates are meaningful in pairs only (high surrogate after low surrogate).

As the test case can generate a single surrogate, it is ill-formed in all above encodings.

I have to mention that JSON allows the appearance of a single surrogate, however if the JSON payload is interpreted in a programing language as a string it potentially cause errors.


