### PR TITLE
Distinguish between numbers with and without fractional component

### DIFF
--- a/pack.toml
+++ b/pack.toml
@@ -24,3 +24,9 @@ test   = "test/test.ipkg"
 type   = "local"
 path   = "simple/test"
 ipkg   = "test.ipkg"
+
+[custom.all.parser-json]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-parser"
+commit = "latest:main"
+ipkg   = "json/parser-json.ipkg"

--- a/simple/src/JSON/Simple/FromJSON.idr
+++ b/simple/src/JSON/Simple/FromJSON.idr
@@ -150,7 +150,8 @@ export
 typeOf : JSON -> String
 typeOf JNull        = "Null"
 typeOf (JBool _)    = "Boolean"
-typeOf (JNumber _)  = "Number"
+typeOf (JDouble _)  = "Double"
+typeOf (JInteger _)  = "Integer"
 typeOf (JString _)  = "String"
 typeOf (JArray _)   = "Array"
 typeOf (JObject _)  = "Object"
@@ -213,17 +214,12 @@ eqString n s = withString n $ \s' =>
   if s == s' then Right () else fail "expected '\{s}' but got '\{s'}'"
 
 export %inline
-withNumber : Lazy String -> Parser Double a -> Parser JSON a
-withNumber = withValue "Number" $ \case JNumber d => Just d; _ => Nothing
+withDouble : Lazy String -> Parser Double a -> Parser JSON a
+withDouble = withValue "Double" $ \case JDouble d => Just d; _ => Nothing
 
 export
 withInteger : Lazy String -> Parser Integer a -> Parser JSON a
-withInteger s f =
-  withNumber s $ \d =>
-    let n := the Integer (cast d)
-     in if d == fromInteger n
-           then f n
-           else fail "not an integer: \{show d}"
+withInteger = withValue "Integer" $ \case JInteger d => Just d; _ => Nothing
 
 export
 withLargeInteger : Lazy String -> Parser Integer a -> Parser JSON a
@@ -357,7 +353,7 @@ FromJSON Bool where
 
 export
 FromJSON Double where
-  fromJSON = withNumber "Double" Right
+  fromJSON = withDouble "Double" Right
 
 export
 FromJSON Bits8 where

--- a/simple/src/JSON/Simple/ToJSON.idr
+++ b/simple/src/JSON/Simple/ToJSON.idr
@@ -71,7 +71,7 @@ maxSafeInteger = 9007199254740991
 ||| as a number.
 export %inline
 smallInteger : Integer -> JSON
-smallInteger = JNumber . fromInteger
+smallInteger = JInteger
 
 ||| Encode an `Integer` (possibly larger than `maxSafeInteger`)
 ||| as a number or a string.
@@ -94,7 +94,7 @@ export %inline
 ToJSON Char where toJSON = JString . singleton
 
 export %inline
-ToJSON Double where toJSON = JNumber
+ToJSON Double where toJSON = JDouble
 
 export %inline
 ToJSON Bits8 where toJSON = smallInteger . cast

--- a/simple/test/src/Main.idr
+++ b/simple/test/src/Main.idr
@@ -311,7 +311,7 @@ prop_anotherRec = roundTrip anotherRec
 prop_anotherRecEnc : Property
 prop_anotherRecEnc = property1 $
   encode (MkARec 12 Nothing (Right False)) ===
-  #"{"v":"MkARec","c":{"anInt":12.0,"perhaps":null,"foo":{"Right":false}}}"#
+  #"{"v":"MkARec","c":{"anInt":12,"perhaps":null,"foo":{"Right":false}}}"#
 
 prop_newtype : Property
 prop_newtype = roundTrip newtype

--- a/src/JSON/Encoder.idr
+++ b/src/JSON/Encoder.idr
@@ -33,8 +33,11 @@ interface Encoder v where
   ||| Encodes a `String` value.
   string : String -> v
 
-  ||| Encodes a `Double` as a JSON `Number`.
-  number : Double -> v
+  ||| Encodes a `Double` as a JSON `Double`.
+  double : Double -> v
+
+  ||| Encodes a `Double` as a JSON `Integer`.
+  integer : Integer -> v
 
   ||| Encodes a `Bool` as a JSON `Boolean`.
   boolean : Bool -> v
@@ -51,7 +54,7 @@ interface Encoder v where
 ||| as a number.
 export %inline
 smallInteger : Encoder v => Integer -> v
-smallInteger = number . fromInteger
+smallInteger = integer
 
 ||| Encode an `Integer` (possibly larger than `masSafeInteger`)
 ||| as a number or a string.
@@ -98,8 +101,11 @@ interface Object obj v => Value v obj | v where
   ||| Tries to convert a value to a `Boolean`.
   getBoolean : v -> Maybe Bool
 
-  ||| Tries to convert a value to a `Number`.
-  getNumber : v -> Maybe Double
+  ||| Tries to convert a value to a `Double`.
+  getDouble : v -> Maybe Double
+
+  ||| Tries to convert a value to an `Integer`.
+  getInteger : v -> Maybe Integer
 
   ||| Tries to convert a value to a `String`.
   getString : v -> Maybe String
@@ -119,7 +125,8 @@ export %inline
 Encoder JSON where
   stringify = show
   string    = JString
-  number    = JNumber
+  double    = JDouble
+  integer   = JInteger
   boolean   = JBool
   null      = JNull
   array     = JArray
@@ -136,7 +143,8 @@ Value JSON (List (String,JSON)) where
 
   typeOf JNull        = "Null"
   typeOf (JBool _)    = "Boolean"
-  typeOf (JNumber _)  = "Number"
+  typeOf (JDouble _)  = "Double"
+  typeOf (JInteger _)  = "Integer"
   typeOf (JString _)  = "String"
   typeOf (JArray _)   = "Array"
   typeOf (JObject _)  = "Object"
@@ -144,8 +152,11 @@ Value JSON (List (String,JSON)) where
   getObject (JObject ps) = Just ps
   getObject _            = Nothing
 
-  getNumber (JNumber v) = Just v
-  getNumber _           = Nothing
+  getDouble (JDouble v) = Just v
+  getDouble _           = Nothing
+
+  getInteger (JInteger v) = Just v
+  getInteger _           = Nothing
 
   getBoolean (JBool v)  = Just v
   getBoolean _            = Nothing

--- a/src/JSON/FromJSON.idr
+++ b/src/JSON/FromJSON.idr
@@ -229,17 +229,12 @@ eqString n s = withString n $ \s' =>
   if s == s' then Right () else fail "expected '\{s}' but got '\{s'}'"
 
 export %inline
-withNumber : Value v obj => Lazy String -> Parser Double a -> Parser v a
-withNumber = withValue "Number" getNumber
+withDouble : Value v obj => Lazy String -> Parser Double a -> Parser v a
+withDouble = withValue "Double" getDouble
 
-export
+export %inline
 withInteger : Value v obj => Lazy String -> Parser Integer a -> Parser v a
-withInteger s f =
-  withNumber s $ \d =>
-    let n = the Integer (cast d)
-    in if d == fromInteger n
-          then f n
-          else fail "not an integer: \{show d}"
+withInteger = withValue "Integer" getInteger
 
 export
 withLargeInteger : Value v obj => Lazy String -> Parser Integer a -> Parser v a
@@ -408,7 +403,7 @@ FromJSON Bool where
 
 export
 FromJSON Double where
-  fromJSON = withNumber "Double" pure
+  fromJSON = withDouble "Double" pure
 
 export
 FromJSON Bits8 where

--- a/src/JSON/ToJSON.idr
+++ b/src/JSON/ToJSON.idr
@@ -84,7 +84,7 @@ export
 ToJSON Char where toJSON = string . singleton
 
 export
-ToJSON Double where toJSON = number
+ToJSON Double where toJSON = double
 
 export
 ToJSON Bits8 where toJSON = smallInteger . cast

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -311,7 +311,7 @@ prop_anotherRec = roundTrip anotherRec
 prop_anotherRecEnc : Property
 prop_anotherRecEnc = property1 $
   encode (MkARec 12 Nothing (Right False)) ===
-  #"{"v":"MkARec","c":{"anInt":12.0,"perhaps":null,"foo":{"Right":false}}}"#
+  #"{"v":"MkARec","c":{"anInt":12,"perhaps":null,"foo":{"Right":false}}}"#
 
 prop_newtype : Property
 prop_newtype = roundTrip newtype


### PR DESCRIPTION
This PR is a companion of [another PR in idris2-parser](https://github.com/stefan-hoeck/idris2-parser/pull/50) and uses the distinction between integers and non-integers exposed in that change.