### PR TITLE
[ new ] support arbitrary precision integers

### DIFF
--- a/simple/src/JSON/Simple/ToJSON.idr
+++ b/simple/src/JSON/Simple/ToJSON.idr
@@ -58,31 +58,6 @@ taggedObject tf cf tag x = JObject [(tf, JString tag), (cf, x)]
 --          Implementations
 --------------------------------------------------------------------------------
 
-||| In Javascript, numbers are represented as IEEE 64bit
-||| floating point numbers. Integers can be represented exactly
-||| in the range [-(2^53-1), 2^53-1]. This library's default
-||| behavior is, that large integers will be encoded as
-||| `string` and smaller values use `number`
-public export
-maxSafeInteger : Integer
-maxSafeInteger = 9007199254740991
-
-||| Encode a small integer (less than or equal to `maxSafeInteger`)
-||| as a number.
-export %inline
-smallInteger : Integer -> JSON
-smallInteger = JInteger
-
-||| Encode an `Integer` (possibly larger than `maxSafeInteger`)
-||| as a number or a string.
-|||
-||| The corresponding decoder for potentially large numbers
-||| will also try both types: Number and string.
-export %inline
-largeInteger : Integer -> JSON
-largeInteger n =
-  if abs n <= maxSafeInteger then smallInteger n else JString $ show n
-
 export
 ToJSON Void where
   toJSON x impossible
@@ -97,37 +72,37 @@ export %inline
 ToJSON Double where toJSON = JDouble
 
 export %inline
-ToJSON Bits8 where toJSON = smallInteger . cast
+ToJSON Bits8 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Bits16 where toJSON = smallInteger . cast
+ToJSON Bits16 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Bits32 where toJSON = smallInteger . cast
+ToJSON Bits32 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Bits64 where toJSON = largeInteger . cast
+ToJSON Bits64 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Int8 where toJSON = smallInteger . cast
+ToJSON Int8 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Int16 where toJSON = smallInteger . cast
+ToJSON Int16 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Int32 where toJSON = smallInteger . cast
+ToJSON Int32 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Int64 where toJSON = largeInteger . cast
+ToJSON Int64 where toJSON = JInteger . cast
 
 export %inline
-ToJSON Int where toJSON = largeInteger . cast
+ToJSON Int where toJSON = JInteger . cast
 
 export %inline
-ToJSON Integer where toJSON = largeInteger
+ToJSON Integer where toJSON = JInteger
 
 export %inline
-ToJSON Nat where toJSON = largeInteger . natToInteger
+ToJSON Nat where toJSON = JInteger . cast
 
 export %inline
 ToJSON Bool where toJSON = JBool

--- a/src/JSON/Encoder.idr
+++ b/src/JSON/Encoder.idr
@@ -10,15 +10,6 @@ import Data.List
 import Data.Vect
 import public JSON.Parser
 
-||| In Javascript, numbers are represented as IEEE 64bit
-||| floating point numbers. Integers can be represented exactly
-||| in the range [-(2^53-1), 2^53-1]. This library's default
-||| behavior is, that large integers will be encoded as
-||| `string` and smaller values use `number`
-public export
-maxSafeInteger : Integer
-maxSafeInteger = 9007199254740991
-
 --------------------------------------------------------------------------------
 --          Encoding
 --------------------------------------------------------------------------------
@@ -49,23 +40,6 @@ interface Encoder v where
   object : List (String,v) -> v
 
   null : v
-
-||| Encode a small integer (less than or equal to `maxSafeInteger`)
-||| as a number.
-export %inline
-smallInteger : Encoder v => Integer -> v
-smallInteger = integer
-
-||| Encode an `Integer` (possibly larger than `masSafeInteger`)
-||| as a number or a string.
-|||
-||| The corresponding decoder for potentially large numbers
-||| will also try both types: Number and string.
-export %inline
-largeInteger : Encoder v => Integer -> v
-largeInteger n = if abs n <= maxSafeInteger
-                    then smallInteger n
-                    else string $ show n
 
 --------------------------------------------------------------------------------
 --          Decoding
@@ -152,8 +126,9 @@ Value JSON (List (String,JSON)) where
   getObject (JObject ps) = Just ps
   getObject _            = Nothing
 
-  getDouble (JDouble v) = Just v
-  getDouble _           = Nothing
+  getDouble (JDouble v)  = Just v
+  getDouble (JInteger v) = Just (cast v)
+  getDouble _            = Nothing
 
   getInteger (JInteger v) = Just v
   getInteger _           = Nothing

--- a/src/JSON/FromJSON.idr
+++ b/src/JSON/FromJSON.idr
@@ -237,16 +237,6 @@ withInteger : Value v obj => Lazy String -> Parser Integer a -> Parser v a
 withInteger = withValue "Integer" getInteger
 
 export
-withLargeInteger : Value v obj => Lazy String -> Parser Integer a -> Parser v a
-withLargeInteger s f v =
-  withInteger s f v `orElse` withString s parseStr v
-  where parseStr : Parser String a
-        parseStr str =
-          case parseInteger {a = Integer} str of
-            Nothing => fail "not an integer: \{show str}"
-            Just n  => f n
-
-export
 boundedIntegral :  Num a
                 => Value v obj
                 => Lazy String
@@ -257,18 +247,6 @@ boundedIntegral s lo up =
   withInteger s $ \n => if n >= lo && n <= up
                          then pure $ fromInteger n
                          else fail "integer out of bounds: \{show n}"
-
-export
-boundedLargeIntegral :  Num a
-                     => Value v obj
-                     => Lazy String
-                     -> (lower : Integer)
-                     -> (upper : Integer)
-                     -> Parser v a
-boundedLargeIntegral s lo up =
-  withLargeInteger s $ \n => if n >= lo && n <= up
-                              then pure $ fromInteger n
-                              else fail "integer out of bounds: \{show n}"
 
 export %inline
 withArray : Value v obj => Lazy String -> Parser (List v) a -> Parser v a
@@ -419,37 +397,37 @@ FromJSON Bits32 where
 
 export
 FromJSON Bits64 where
-  fromJSON = boundedLargeIntegral "Bits64" 0 0xffffffffffffffff
+  fromJSON = boundedIntegral "Bits64" 0 0xffffffffffffffff
 
 export
 FromJSON Int where
-  fromJSON = boundedLargeIntegral "Int" (-0x8000000000000000) 0x7fffffffffffffff
+  fromJSON = boundedIntegral "Int" (-0x8000000000000000) 0x7fffffffffffffff
 
 export
 FromJSON Int8 where
-  fromJSON = boundedLargeIntegral "Int8" (-0x80) 0x7f
+  fromJSON = boundedIntegral "Int8" (-0x80) 0x7f
 
 export
 FromJSON Int16 where
-  fromJSON = boundedLargeIntegral "Int16" (-0x8000) 0x7fff
+  fromJSON = boundedIntegral "Int16" (-0x8000) 0x7fff
 
 export
 FromJSON Int32 where
-  fromJSON = boundedLargeIntegral "Int32" (-0x80000000) 0x7fffffff
+  fromJSON = boundedIntegral "Int32" (-0x80000000) 0x7fffffff
 
 export
 FromJSON Int64 where
-  fromJSON = boundedLargeIntegral "Int64" (-0x8000000000000000) 0x7fffffffffffffff
+  fromJSON = boundedIntegral "Int64" (-0x8000000000000000) 0x7fffffffffffffff
 
 export
 FromJSON Nat where
-  fromJSON = withLargeInteger "Nat" $ \n =>
+  fromJSON = withInteger "Nat" $ \n =>
     if n >= 0 then pure $ fromInteger n
     else fail #"not a natural number: \#{show n}"#
 
 export
 FromJSON Integer where
-  fromJSON = withLargeInteger "Integer" pure
+  fromJSON = withInteger "Integer" pure
 
 export
 FromJSON String where

--- a/src/JSON/ToJSON.idr
+++ b/src/JSON/ToJSON.idr
@@ -87,37 +87,37 @@ export
 ToJSON Double where toJSON = double
 
 export
-ToJSON Bits8 where toJSON = smallInteger . cast
+ToJSON Bits8 where toJSON = integer . cast
 
 export
-ToJSON Bits16 where toJSON = smallInteger . cast
+ToJSON Bits16 where toJSON = integer . cast
 
 export
-ToJSON Bits32 where toJSON = smallInteger . cast
+ToJSON Bits32 where toJSON = integer . cast
 
 export
-ToJSON Bits64 where toJSON = largeInteger . cast
+ToJSON Bits64 where toJSON = integer . cast
 
 export
-ToJSON Int8 where toJSON = smallInteger . cast
+ToJSON Int8 where toJSON = integer . cast
 
 export
-ToJSON Int16 where toJSON = smallInteger . cast
+ToJSON Int16 where toJSON = integer . cast
 
 export
-ToJSON Int32 where toJSON = smallInteger . cast
+ToJSON Int32 where toJSON = integer . cast
 
 export
-ToJSON Int64 where toJSON = largeInteger . cast
+ToJSON Int64 where toJSON = integer . cast
 
 export
-ToJSON Int where toJSON = largeInteger . cast
+ToJSON Int where toJSON = integer . cast
 
 export
-ToJSON Integer where toJSON = largeInteger
+ToJSON Integer where toJSON = integer
 
 export
-ToJSON Nat where toJSON = largeInteger . natToInteger
+ToJSON Nat where toJSON = integer . cast
 
 export
 ToJSON Bool where toJSON = boolean


### PR DESCRIPTION
This is a follow-up on #33 : All integers are now encoded as (arbitrary precision) `Integers`. In addition, a `Double` can be extracted both from `JDouble` as well as `JInteger`.