### PR TITLE
[ ambig ] Make a call to `<|>` in the derived code unambiguous

### DIFF
--- a/simple/src/Derive/FromJSON/Simple.idr
+++ b/simple/src/Derive/FromJSON/Simple.idr
@@ -146,7 +146,7 @@ parameters (nms : List Name) (o : Options) (tpeName : TTImp) (err : TTImp)
             iCase `(x) implicitFalse (clauses ++ [catch])
 
       untagged : TTImp
-      untagged = foldl (\t,c => `(~(t) <|> ~(rhs c))) (rhs d) ds
+      untagged = foldl (\t,c => `(JSON.Simple.FromJSON.(<|>) ~(t) ~(rhs c))) (rhs d) ds
 
 
   decSum : (constants, withArgs : List DCon) -> TTImp

--- a/src/Derive/FromJSON.idr
+++ b/src/Derive/FromJSON.idr
@@ -144,14 +144,14 @@ parameters (nms : List Name) (o : Options) (tpeName : TTImp) (err : TTImp)
             iCase `(x) implicitFalse (clauses ++ [catch])
 
       untagged : TTImp
-      untagged = foldl (\t,c => `(~(t) <|> ~(rhs c))) (rhs d) ds
+      untagged = foldl (\t,c => `(JSON.FromJSON.(<|>) ~(t) ~(rhs c))) (rhs d) ds
 
 
   decSum : (constants, withArgs : List DCon) -> TTImp
   decSum [] []        = `(fail $ "Uninhabited type: " ++ ~(tpeName))
   decSum [] (w :: ws) = withArgs w ws
   decSum cs []        = consts cs
-  decSum cs (w :: ws) = `(~(consts cs) <|> ~(withArgs w ws))
+  decSum cs (w :: ws) = `(JSON.FromJSON.(<|>) ~(consts cs) ~(withArgs w ws))
 
   decRecord : DCon -> TTImp
   decRecord c = case c.args of


### PR DESCRIPTION
After #52 I'm getting
```console
[ build ] Error: Error during reflection: While processing right hand side of fromJsonJsonSchema. Ambiguous elaboration. Possible results:
[ build ]     ?delayed JSON.Simple.FromJSON.(<|>) (?delayed Prelude.(.) JSON.Simple.FromJSON.fromJSON)
[ build ]     ?postpone [no locals in scope]
[ build ] 
[ build ] Derive.FromJSON.Simple:149:40--149:43
```

I propose to derive unambiguos code here.

---

Funny and important thing, #52 seems to introduce a regression. This ambiguity error, actually, masks the real error. After the change from this PR compilation gives the following error:

```console
[ build ] Error: deriveJsonSchema is not total, possibly not terminating due to function MicroJsonSchema.implFromJSONJsonSchema being reachable via MicroJsonSchema.loadJsonSchema -> MicroJsonSchema.implFromJSONJsonSchema
[ build ] 
[ build ] MicroJsonSchema:141:1--142:45
[ build ]  141 | export
[ build ]  142 | deriveJsonSchema : SchemaSource -> Elab Type
[ build ] 
[ build ] Error: fromJsonJsonSchema is not total, possibly not terminating due to call to MicroJsonSchema.implFromJSONJsonSchema
[ build ] 
[ build ] Error: implFromJSONJsonSchema is not total, possibly not terminating due to recursive path MicroJsonSchema.fromJsonJsonSchema -> MicroJsonSchema.implFromJSONJsonSchema
[ build ] 
[ build ] Error: loadJsonSchema is not total, possibly not terminating due to call to MicroJsonSchema.implFromJSONJsonSchema
```

where `JsonSchema` is my type for this I try to derive `FromJSON`, and `loadJsonSchema` is my total function calling `fromJSON`. Other functions seems to be derived by `json-simple` library.