### PR TITLE
[ compat ] adjust to upstream changes

### DIFF
--- a/pack.toml
+++ b/pack.toml
@@ -28,23 +28,23 @@ ipkg   = "test.ipkg"
 [custom.all.parser]
 type   = "git"
 url    = "https://github.com/stefan-hoeck/idris2-parser"
-commit = "latest:simplify_errs"
+commit = "latest:main"
 ipkg   = "parser.ipkg"
 
 [custom.all.parser-json]
 type   = "git"
 url    = "https://github.com/stefan-hoeck/idris2-parser"
-commit = "latest:simplify_errs"
+commit = "latest:main"
 ipkg   = "json/parser-json.ipkg"
 
 [custom.all.parser-show]
 type   = "git"
 url    = "https://github.com/stefan-hoeck/idris2-parser"
-commit = "latest:simplify_errs"
+commit = "latest:main"
 ipkg   = "show/parser-show.ipkg"
 
 [custom.all.pretty-show]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-pretty-show"
-commit = "latest:simplify_errs"
+commit = "latest:main"
 ipkg   = "pretty-show.ipkg"

--- a/pack.toml
+++ b/pack.toml
@@ -37,6 +37,12 @@ url    = "https://github.com/stefan-hoeck/idris2-parser"
 commit = "latest:simplify_errs"
 ipkg   = "json/parser-json.ipkg"
 
+[custom.all.parser-show]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-parser"
+commit = "latest:simplify_errs"
+ipkg   = "show/parser-show.ipkg"
+
 [custom.all.pretty-show]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-pretty-show"

--- a/pack.toml
+++ b/pack.toml
@@ -25,14 +25,20 @@ type   = "local"
 path   = "simple/test"
 ipkg   = "test.ipkg"
 
+[custom.all.parser]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-parser"
+commit = "latest:simplify_errs"
+ipkg   = "parser.ipkg"
+
 [custom.all.parser-json]
 type   = "git"
 url    = "https://github.com/stefan-hoeck/idris2-parser"
-commit = "latest:main"
+commit = "latest:simplify_errs"
 ipkg   = "json/parser-json.ipkg"
 
 [custom.all.pretty-show]
 type   = "github"
 url    = "https://github.com/stefan-hoeck/idris2-pretty-show"
-commit = "latest:main"
+commit = "latest:simplify_errs"
 ipkg   = "pretty-show.ipkg"

--- a/simple/src/JSON/Simple/FromJSON.idr
+++ b/simple/src/JSON/Simple/FromJSON.idr
@@ -60,7 +60,7 @@ f <|> g = \vv => f vv `orElse` g vv
 public export
 data DecodingErr : Type where
   JErr      : JSONErr -> DecodingErr
-  JParseErr : (FileContext,ParseErr)-> DecodingErr
+  JParseErr : ParseError JSErr -> DecodingErr
 
 %runElab derive "DecodingErr" [Show,Eq]
 
@@ -113,12 +113,18 @@ export
 formatError : JSONPath -> String -> String
 formatError path msg = "Error in " ++ formatPath path ++ ": " ++ msg
 
+export
+Interpolation DecodingErr where
+  interpolate (JErr (p,s))  = formatError p s
+  interpolate (JParseErr x) = interpolate x
+
 ||| Pretty prints a decoding error. In case of a parsing error,
 ||| this might be printed on several lines.
-export
+|||
+||| DEPRECATED: Use `interpolate` instead
+export %deprecate
 prettyErr : (input : String) -> DecodingErr -> String
-prettyErr _ (JErr (p,s))  = formatError p s
-prettyErr i (JParseErr (fc,err)) = printParseError i fc err
+prettyErr _ = interpolate
 
 --------------------------------------------------------------------------------
 --          Interface

--- a/src/JSON/Encoder.idr
+++ b/src/JSON/Encoder.idr
@@ -64,7 +64,7 @@ interface Object obj v => Value v obj | v where
   typeOf : v -> String
 
   ||| Tries to convert a string to an intermediare value.
-  parse : Origin -> String -> Either (FileContext,ParseErr) v
+  parse : Origin -> String -> Either (ParseError JSErr) v
 
   ||| Tries to convert a value to an `Object`.
   getObject : v -> Maybe obj

--- a/src/JSON/FromJSON.idr
+++ b/src/JSON/FromJSON.idr
@@ -58,7 +58,7 @@ f <|> g = \vv => f vv `orElse` g vv
 public export
 data DecodingErr : Type where
   JErr      : JSONErr -> DecodingErr
-  JParseErr : (FileContext,ParseErr)-> DecodingErr
+  JParseErr : ParseError JSErr-> DecodingErr
 
 %runElab derive "DecodingErr" [Show,Eq]
 
@@ -112,12 +112,18 @@ export
 formatError : JSONPath -> String -> String
 formatError path msg = "Error in " ++ formatPath path ++ ": " ++ msg
 
+export
+Interpolation DecodingErr where
+  interpolate (JErr (p,s))  = formatError p s
+  interpolate (JParseErr x) = interpolate x
+
 ||| Pretty prints a decoding error. In case of a parsing error,
 ||| this might be printed on several lines.
-export
+|||
+||| DEPRECATED: Use `interpolate` instead
+export %deprecate
 prettyErr : (input : String) -> DecodingErr -> String
-prettyErr _ (JErr (p,s))  = formatError p s
-prettyErr i (JParseErr (fc,err)) = printParseError i fc err
+prettyErr _ = interpolate
 
 --------------------------------------------------------------------------------
 --          Interface


### PR DESCRIPTION
This is related to #50. I'd like to extract the core data types such as `Bounds`, `Bounded`, but also `ParseError` from idris2-parser to their own library (idris2-parser-types) and reuse them in parser as well as ilex. The first step is a simplification of the error types, which is ready to merge upstream.